### PR TITLE
Fix value mapping

### DIFF
--- a/lib/internal/src/adc.cpp
+++ b/lib/internal/src/adc.cpp
@@ -51,12 +51,15 @@ uint16_t NO_INLINE adc::read_register()
 
 uint16_t NO_INLINE adc::read()
 {
-    return 0;
+    return test_value;
 }
 
 void adc::init(uint8_t channel)
 {
 }
 
+void adc::test_set(uint16_t value) {
+    test_value = value;
+}
 
 #endif

--- a/lib/internal/src/adc.h
+++ b/lib/internal/src/adc.h
@@ -9,7 +9,7 @@ class adc
 {
 public:
     /// Read a raw ADC value.
-    static uint16_t read();
+    uint16_t read();
 
     /// Set up the ADC configuration registers to start sampling from the given channel.
     void init(uint8_t channel);
@@ -35,13 +35,13 @@ private:
     };
 
     /// Tell the ADC component to start measurement.
-    static void start();
+    void start();
 
     /// Wait until the ADC has finished its measurement
-    static void wait_for_result();
+    void wait_for_result();
 
     /// read the ADC register.
-    static uint16_t read_register();
+    uint16_t read_register();
 
 };
 

--- a/lib/internal/src/adc.h
+++ b/lib/internal/src/adc.h
@@ -14,6 +14,10 @@ public:
     /// Set up the ADC configuration registers to start sampling from the given channel.
     void init(uint8_t channel);
 
+#ifdef UNIT_TEST
+    void test_set(uint16_t value);
+#endif
+
 private:
     /// template meta function that, given a cpu frequency and a required maximum frequency, finds a divider (as a power of two) that
     /// will result in the highest result frequency that is at most the given result frequency.
@@ -33,6 +37,10 @@ private:
         // try a higher divider (power of two).
         static const uint8_t value = divider<cpu_khz, max_khz, (proposed + 1)>::value;
     };
+
+#ifdef UNIT_TEST
+    uint16_t test_value;
+#endif
 
     /// Tell the ADC component to start measurement.
     void start();

--- a/lib/internal/src/mapper.cpp
+++ b/lib/internal/src/mapper.cpp
@@ -29,7 +29,7 @@ void NO_INLINE PedalMapper::rescale_range()
 
 		// adapt the range so that the lower 1/8 of the range all registers as '0' (maximum down position)
 		translation_offset -= translation_scale/scale_cutoff;
-		translation_scale -= translation_scale/scale_cutoff;
+		translation_scale += translation_scale/scale_cutoff;
 	}
 	else
 	{

--- a/lib/internal/src/mapper.h
+++ b/lib/internal/src/mapper.h
@@ -29,7 +29,7 @@ private:
 	// calibration values.
 	int32_t translation_scale; ///<this is the distance between lowest ever and highest ever value measured. Negative if voltage increases with pedal-down.
 	int16_t translation_offset; ///< this is either the lowest or highest raw value measured, depending on whether voltage goes up or down if pedal goes down.
-	const int16_t scale_cutoff = 6;
+	static const int16_t scale_cutoff = 6;
 
 	/// From the maximum and minimum measured ADC values determine:
 	/// * the direction of the pedal (whether the voltage goes up or down when the pedal is depressed).

--- a/test/test_mapper/test_mapper.cpp
+++ b/test/test_mapper/test_mapper.cpp
@@ -1,24 +1,24 @@
 #include <unity.h>
+#include "adc.h"
+#include "mapper.h"
+
+adc adc;
+PedalMapper mapper;
 
 void setUp(void) {
-    // set stuff up here
+    mapper.init_pedal_calibration(adc);
 }
 
 void tearDown(void) {
     // clean stuff up here
 }
 
-void test_foo(void) {
-    TEST_ASSERT_EQUAL(2, 2);
-}
-
-void test_bar(void) {
-    TEST_ASSERT_EQUAL(2, 3);
+void test_mapper(void) {
+    mapper.read_scaled_pedal(adc);
 }
 
 int main( int argc, char **argv) {
     UNITY_BEGIN();
-    RUN_TEST(test_foo);
-    RUN_TEST(test_bar);
+    RUN_TEST(test_mapper);
     UNITY_END();
 }

--- a/test/test_mapper/test_mapper.cpp
+++ b/test/test_mapper/test_mapper.cpp
@@ -6,7 +6,6 @@ adc adc;
 PedalMapper mapper;
 
 void setUp(void) {
-    mapper.init_pedal_calibration(adc);
 }
 
 void tearDown(void) {
@@ -14,7 +13,19 @@ void tearDown(void) {
 }
 
 void test_mapper(void) {
+    // start at some rest value to perform initial calibration
+    adc.test_set(508);
+    mapper.init_pedal_calibration(adc);
+
+    // simulate a full push down to do self-calibration
+    adc.test_set(463);
     mapper.read_scaled_pedal(adc);
+    // the mapper is now calibrated and ready for business.
+
+    // At rest, the pot value should be near 255 (not quite 255 because of
+    // rounding errors)
+    adc.test_set(508);
+    TEST_ASSERT_GREATER_OR_EQUAL_CHAR(250, mapper.read_scaled_pedal(adc));
 }
 
 int main( int argc, char **argv) {


### PR DESCRIPTION
Fixes #2 .

Once the mapper has found out in which direction the input value goes (by comparing the median against the midpoint), it sets the two variables `translation_offset` and `translation_scale` so the min and max input values map to 0 and 255 respectively. Then, it adjusts them in order to compensate for [the stomp problem](https://rurandom.org/justintime/w/Digital_FD-8_pedal#The_stomp_problem) by increasing the scale and moving the offset up or down a little. But, in case the median is below the midpoint, `translation_scale` was decreased rather than increased. This caused input values near the higher end of the scale, i.e. at rest or light foot push, to be mapped (in `PedalMapper::scale_down`) to values higher than 255, causing an overflow in the 8-bit value accepted by the digipot. After flipping the sign on `translation_scale` adjustment, no overflow is observed and neither is the wraparound.

In addition to the fix, this PR adds some unit testing against the mapper class using a mock implementation of the `adc` class and some real-world measurements. This allowed to better investigate the root cause of the value wraparound.

The `adc` members are made non-static to avoid some weird linking errors when compiling the unit test (``undefined reference to `adc::test_value'``), this increased the flash usage from 644 to 660 bytes. With the remaining changes the flash usage is 682 bytes.